### PR TITLE
Fix the alias option

### DIFF
--- a/alias.nix
+++ b/alias.nix
@@ -1,0 +1,9 @@
+{
+  nh_darwin,
+  runCommand,
+  lib,
+}:
+runCommand "${nh_darwin.name}-alias" { } ''
+  mkdir -p "$out/bin"
+  ln -s ${lib.escapeShellArg (lib.getExe nh_darwin)} "$out/bin/nh"
+''

--- a/alias.nix
+++ b/alias.nix
@@ -2,8 +2,20 @@
   nh_darwin,
   runCommand,
   lib,
+  stdenv,
+  installShellFiles,
 }:
-runCommand "${nh_darwin.name}-alias" { } ''
-  mkdir -p "$out/bin"
-  ln -s ${lib.escapeShellArg (lib.getExe nh_darwin)} "$out/bin/nh"
-''
+runCommand "${nh_darwin.name}-alias" { nativeBuildInputs = [ installShellFiles ]; } (
+  ''
+    mkdir -p "$out/bin"
+    ln -s ${lib.escapeShellArg (lib.getExe nh_darwin)} "$out/bin/nh"
+  ''
+  +
+    lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) # sh
+      ''
+        installShellCompletion --cmd nh \
+          --bash <("$out/bin/nh" completions --shell bash) \
+          --zsh <("$out/bin/nh" completions --shell zsh) \
+          --fish <("$out/bin/nh" completions --shell fish)
+      ''
+)

--- a/darwin-module.nix
+++ b/darwin-module.nix
@@ -3,14 +3,7 @@ self: { config, lib, pkgs, ... }:
 let
   cfg = config.programs.nh;
   nh_darwin = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
-  nh = (pkgs.runCommand "${nh_darwin.pname}-docker-compat-${nh_darwin.version}"
-    {
-      outputs = [ "out" ];
-      inherit (nh_darwin) meta;
-    } ''
-    mkdir -p $out/bin
-    ln -s ${nh_darwin}/bin/nh_darwin $out/bin/nh
-  '');
+  nh = pkgs.callPackage ./alias.nix { nh_darwin = cfg.package; };
 in
 {
   meta.maintainers = [ lib.maintainers.ToyVo ];

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -4,14 +4,7 @@ self: { config, lib, pkgs, ... }:
 let
   cfg = config.programs.nh;
   nh_darwin = self.packages.${pkgs.stdenv.hostPlatform.system}.nh_darwin;
-  nh = (pkgs.runCommand "${nh_darwin.pname}-docker-compat-${nh_darwin.version}"
-    {
-      outputs = [ "out" ];
-      inherit (nh_darwin) meta;
-    } ''
-    mkdir -p $out/bin
-    ln -s ${nh_darwin}/bin/nh_darwin $out/bin/nh
-  '');
+  nh = pkgs.callPackage ./alias.nix { nh_darwin = cfg.package; };
 in
 {
   meta.maintainers = with lib.maintainers; [ johnrtitor ];

--- a/module.nix
+++ b/module.nix
@@ -1,20 +1,16 @@
 self: { config, pkgs, lib, ... }:
 let
+  cfg = config.programs.nh;
   nh_darwin = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
-  nh = (pkgs.runCommand "${nh_darwin.pname}-docker-compat-${nh_darwin.version}"
-    {
-      outputs = [ "out" ];
-      inherit (nh_darwin) meta;
-    } ''
-    mkdir -p $out/bin
-    ln -s ${nh_darwin}/bin/nh_darwin $out/bin/nh
-  '');
+  nh = pkgs.callPackage ./alias.nix { nh_darwin = cfg.package; };
 in
 {
   options.programs.nh.alias = lib.mkEnableOption "Enable alias of nh_darwin to nh";
   config = {
     nixpkgs.overlays = [ self.overlays.default ];
     programs.nh.package = lib.mkDefault nh_darwin;
-    environment.systemPackages = lib.mkIf (config.programs.nh.enable && config.programs.nh.alias) [ nh ];
+    environment.systemPackages = lib.mkIf (cfg.enable && cfg.alias) [
+      nh
+    ];
   };
 }

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -3,13 +3,19 @@ use clap_complete::generate;
 use color_eyre::Result;
 use tracing::instrument;
 
-const NH_NAME: &str = env!("CARGO_PKG_NAME");
-
 impl NHRunnable for interface::CompletionArgs {
     #[instrument(ret, level = "trace")]
     fn run(&self) -> Result<()> {
         let mut cmd = <NHParser as clap::CommandFactory>::command();
-        generate(self.shell, &mut cmd, NH_NAME, &mut std::io::stdout());
+        generate(
+            self.shell,
+            &mut cmd,
+            std::path::Path::new(&std::env::args_os().next().expect("current executable"))
+                .file_name()
+                .expect("executable filename")
+                .to_string_lossy(),
+            &mut std::io::stdout(),
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
Previously, using `programs.nh.alias = true` would give an error since the `nh_darwin` package did not have a `pname` attribute. This PR fixes that issue by changing how the alias derivation name is built, along with getting rid of the meaningless `docker-compat` and also providing shell completions for the `nh` command.