### PR TITLE
feat: support different flakes for os and home

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,6 +788,7 @@ dependencies = [
  "derive_builder",
  "dialoguer",
  "elasticsearch-dsl",
+ "etcetera",
  "hostname",
  "humantime",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ color-eyre = { version = "0.6.2", default-features = false, features = [
 derive_builder = "0.20.0"
 dialoguer = { version = "0.11.0", default-features = false }
 elasticsearch-dsl = "0.4.19"
+etcetera = "0.8.0"
 hostname = "0.4"
 humantime = "2.1.0"
 nix = { version = "0.29.0", default-features = false, features = [

--- a/module.nix
+++ b/module.nix
@@ -1,4 +1,10 @@
-self: { config, pkgs, lib, ... }:
+self:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 let
   cfg = config.programs.nh;
   nh_darwin = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
@@ -6,11 +12,35 @@ let
 in
 {
   options.programs.nh.alias = lib.mkEnableOption "Enable alias of nh_darwin to nh";
+  options.programs.nh.flake = {
+    os = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        The path that will be used for the `NH_OS_FLAKE` environment variable.
+
+        `NH_OS_FLAKE` is used by nh_darwin as the default flake for performing actions on NixOS/nix-darwin, like `nh_darwin os switch`.
+      '';
+    };
+    home = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        The path that will be used for the `NH_HOME_FLAKE` environment variable.
+
+        `NH_HOME_FLAKE` is used by nh_darwin as the default flake for performing actions on home-manager, like `nh_darwin home switch`.
+      '';
+    };
+  };
   config = {
     nixpkgs.overlays = [ self.overlays.default ];
     programs.nh.package = lib.mkDefault nh_darwin;
     environment.systemPackages = lib.mkIf (cfg.enable && cfg.alias) [
       nh
+    ];
+    environment.variables = lib.mkMerge [
+      (lib.mkIf (cfg.flake.os != null) { NH_OS_FLAKE = cfg.flake.os; })
+      (lib.mkIf (cfg.flake.home != null) { NH_HOME_FLAKE = cfg.flake.home; })
     ];
   };
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,48 @@
+use std::{
+    env::var_os,
+    path::PathBuf,
+};
+
+use etcetera::{app_strategy::Xdg, AppStrategy, AppStrategyArgs, HomeDirError};
+
+#[derive(Debug)]
+pub struct Config {
+    pub os_flake: PathBuf,
+    pub home_flake: PathBuf,
+}
+
+impl Config {
+    pub fn from_env() -> Result<Self, HomeDirError> {
+        let flake = var_os("NH_FLAKE").or_else(|| var_os("FLAKE"));
+        let os_flake = var_os("NH_OS_FLAKE")
+            .or_else(|| flake.clone())
+            .map_or_else(
+                || {
+                    if cfg!(target_os = "macos") {
+                        Xdg::new(AppStrategyArgs {
+                            app_name: "nix-darwin".to_owned(),
+                            ..Default::default()
+                        })
+                        .map(|x| x.config_dir())
+                    } else {
+                        Ok(PathBuf::from("/etc/nixos"))
+                    }
+                },
+                |x| Ok(PathBuf::from(x)),
+            )?;
+        let home_flake = var_os("NH_HOME_FLAKE").or(flake).map_or_else(
+            || {
+                Xdg::new(AppStrategyArgs {
+                    app_name: "home-manager".to_owned(),
+                    ..Default::default()
+                })
+                .map(|x| x.config_dir())
+            },
+            |x| Ok(PathBuf::from(x)),
+        )?;
+        Ok(Self {
+            os_flake,
+            home_flake,
+        })
+    }
+}

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -2,26 +2,41 @@ use ambassador::{delegatable_trait, Delegate};
 use anstyle::Style;
 use clap::{builder::Styles, Args, Parser, Subcommand};
 use color_eyre::Result;
-use std::{ffi::OsString, ops::Deref, path::Path, path::PathBuf};
+use std::{
+    ffi::OsString,
+    fmt::Display,
+    ops::Deref,
+    path::{Path, PathBuf},
+    sync::LazyLock,
+};
+
+pub static FLAKE_CONFIG: LazyLock<crate::config::Config> =
+    LazyLock::new(|| crate::config::Config::from_env().expect("unable to get home directory"));
 
 #[derive(Debug, Clone, Default)]
 pub struct FlakeRef(String);
 impl From<&str> for FlakeRef {
     fn from(s: &str) -> Self {
-        FlakeRef(s.to_string())
+        Self(s.to_owned())
     }
 }
 
+impl AsRef<str> for FlakeRef {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
 impl AsRef<Path> for FlakeRef {
     fn as_ref(&self) -> &Path {
         self.0.as_ref()
     }
 }
-// impl std::fmt::Display for FlakeRef {
-//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-//         write!(f, "{}", self.0)
-//     }
-// }
+
+impl Display for FlakeRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 impl Deref for FlakeRef {
     type Target = String;
@@ -108,12 +123,7 @@ pub struct OsRebuildArgs {
     pub common: CommonRebuildArgs,
 
     /// Flake reference to build
-    #[cfg(target_os = "linux")]
-    #[arg(env = "FLAKE", value_hint = clap::ValueHint::DirPath, default_value = "/etc/nixos")]
-    pub flakeref: FlakeRef,
-    /// Flake reference to build
-    #[cfg(target_os = "macos")]
-    #[arg(env = "FLAKE", value_hint = clap::ValueHint::DirPath, default_value = "~/.nixpkgs")]
+    #[arg(value_hint = clap::ValueHint::DirPath, default_value_t = FlakeRef(FLAKE_CONFIG.os_flake.to_string_lossy().into_owned()))]
     pub flakeref: FlakeRef,
 
     /// Output to choose from the flakeref. Hostname is used by default
@@ -172,7 +182,7 @@ pub struct CommonRebuildArgs {
 
     /// Path to save the result link. Defaults to using a temporary directory.
     #[arg(long, short)]
-    pub out_link: Option<PathBuf>
+    pub out_link: Option<PathBuf>,
 }
 
 #[derive(Args, Debug)]
@@ -285,7 +295,7 @@ pub struct HomeRebuildArgs {
     pub common: CommonRebuildArgs,
 
     /// Flake reference to build
-    #[arg(env = "FLAKE", value_hint = clap::ValueHint::DirPath, default_value = "~/.config/home-manager")]
+    #[arg(value_hint = clap::ValueHint::DirPath, default_value_t = FlakeRef(FLAKE_CONFIG.home_flake.to_string_lossy().into_owned()))]
     pub flakeref: FlakeRef,
 
     /// Name of the flake homeConfigurations attribute, like username@hostname

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod logging;
 mod nixos;
 mod search;
 mod util;
+mod config;
 
 use crate::interface::NHParser;
 use crate::interface::NHRunnable;


### PR DESCRIPTION
Also fixes the issue with default nix-darwin and home-manager paths not working due to the default values having a `~` instead of the home directory path.

Configuration (from least priority to most):
- `FLAKE` - still supported
- `NH_FLAKE` - same as `FLAKE` but is namespaced so it does not cause issues with other tooling that might expect a variable named `FLAKE`
- `NH_OS_FLAKE` and `NH_HOME_FLAKE` - paths to nix-darwin/NixOS and home-manager flakes respectively

Nix module configuration:
- `programs.nh.flake` does not accept strings and null anymore (this could be changed but I'm not proficient enough to properly handle that)
- `programs.nh.flake.os` and `programs.nh.flake.home` behave just like the old `programs.nh.flake` did, but they are responsible for setting `NH_OS_FLAKE` and `NH_HOME_FLAKE` individually